### PR TITLE
added option to set the ReceiveMode of a service bus subscription

### DIFF
--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBusOptions.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBusOptions.cs
@@ -143,16 +143,18 @@ namespace Foundatio.Messaging {
         public string SubscriptionUserMetadata { get; set; }
 
         public RetryPolicy SubscriptionRetryPolicy { get; set; }
+
+        public ReceiveMode SubscriptionReceiveMode { get; set; } = ReceiveMode.ReceiveAndDelete;
     }
 
     public class AzureServiceBusMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<
         AzureServiceBusMessageBusOptions, AzureServiceBusMessageBusOptionsBuilder> {
-        
+
         public AzureServiceBusMessageBusOptionsBuilder ConnectionString(string connectionString) {
             Target.ConnectionString = connectionString;
             return this;
         }
-        
+
         public AzureServiceBusMessageBusOptionsBuilder PrefetchCount(int prefetchCount) {
             Target.PrefetchCount = prefetchCount;
             return this;
@@ -290,6 +292,11 @@ namespace Foundatio.Messaging {
 
         public AzureServiceBusMessageBusOptionsBuilder SubscriptionRetryPolicy(RetryPolicy subscriptionRetryPolicy) {
             Target.SubscriptionRetryPolicy = subscriptionRetryPolicy ?? throw new ArgumentNullException(nameof(subscriptionRetryPolicy));
+            return this;
+        }
+
+        public AzureServiceBusMessageBusOptionsBuilder SubscriptionReceiveMode(ReceiveMode receiveMode) {
+            Target.SubscriptionReceiveMode = receiveMode;
             return this;
         }
     }


### PR DESCRIPTION
I have the need to ensure delivery of messages on the service bus and being able to configure the client to use `ReceiveMode.PeekLock` to guarantee delivery.

I think this change is all that is required.  I'll admit that I haven't gone through thoroughly to see if there's any reason not to lock into using `ReceiveMode.ReceiveAndDelete` but as far as I can tell it should be fine.

Also I included usage of the cancellation token into creating the subscription which seemed to make sense as well. 