### PR TITLE
Explicitly reference newer versions of libraries with CVEs

### DIFF
--- a/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
+++ b/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
@@ -6,9 +6,11 @@
 
     <PackageReference Include="Foundatio" Version="10.7.1" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
 
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+    <!-- NOTE: Forcing minimum for security patch. Remove once SDK versions are updated -->
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Condition="" Version="(2.3.24,)" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <!-- NOTE: Forcing minimum for security patch. Remove once SDK versions are updated -->
+    <PackageReference Include="Newtonsoft.Json" Version="(13.0.3,)" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
+++ b/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
@@ -5,6 +5,10 @@
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
 
     <PackageReference Include="Foundatio" Version="10.7.1" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

I've explicitly referenced two nuget packages to prevent the implicit versions from being referenced:

* Newtonsoft.Json - 13.0.3
* Microsoft.Rest.ClientRuntime - 2.3.24

This is because the implicit versions (10.0.3 for Newtonsoft, 2.3.20.0 for ClientRuntime) have active CVEs that's triggering my build pipeline checks:

* https://nvd.nist.gov/vuln/detail/CVE-2024-21907
* https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2022-26907

## Other Notes
Both of these referenced libraries are due to the dependency on the now-deprecated `Microsoft.Azure.Management.ServiceBus` library. Rather than replacing it with its `Azure.ResourceManager.ServiceBus` alternative that's still under support, I am just doing this in hopes it wont create a bunch more downstream work.

If there's appetite, I could replace Management.ServiceBus instead but I am not familiar with the test environment of this package at all.