### PR TITLE
Fix NRT errors and enable TreatWarningsAsErrors

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,6 +16,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/samples/Foundatio.AzureServiceBus.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Dequeue/Program.cs
@@ -37,8 +37,9 @@ rootCommand.SetAction(async parseResult =>
                               Environment.GetEnvironmentVariable("AZURE_SERVICEBUS_CONNECTION_STRING") ??
                               EmulatorConnectionString;
 
-    string queueName = parseResult.GetValue(queueOption)!;
+    string? queueName = parseResult.GetValue(queueOption);
     int count = parseResult.GetValue(countOption);
+    ArgumentException.ThrowIfNullOrEmpty(queueName);
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Service Bus Emulator" : "Custom connection string")}");
     Console.WriteLine($"Queue: {queueName}");

--- a/samples/Foundatio.AzureServiceBus.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Dequeue/Program.cs
@@ -38,8 +38,9 @@ rootCommand.SetAction(async parseResult =>
                               EmulatorConnectionString;
 
     string? queueName = parseResult.GetValue(queueOption);
+    ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
+
     int count = parseResult.GetValue(countOption);
-    ArgumentException.ThrowIfNullOrEmpty(queueName);
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Service Bus Emulator" : "Custom connection string")}");
     Console.WriteLine($"Queue: {queueName}");

--- a/samples/Foundatio.AzureServiceBus.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Dequeue/Program.cs
@@ -37,7 +37,7 @@ rootCommand.SetAction(async parseResult =>
                               Environment.GetEnvironmentVariable("AZURE_SERVICEBUS_CONNECTION_STRING") ??
                               EmulatorConnectionString;
 
-    string queueName = parseResult.GetValue(queueOption);
+    string queueName = parseResult.GetValue(queueOption)!;
     int count = parseResult.GetValue(countOption);
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Service Bus Emulator" : "Custom connection string")}");
@@ -102,7 +102,7 @@ static async Task DequeueMessages(string connectionString, string queueName, int
                 processed++;
 
                 logger.LogInformation("Dequeued message {MessageId}: '{Message}' from '{Source}' at {Timestamp}",
-                    entry.Id, entry.Value.Message, entry.Value.Source, entry.Value.Timestamp);
+                    entry.Id, entry.Value?.Message, entry.Value?.Source, entry.Value?.Timestamp);
 
                 logger.LogInformation("  CorrelationId: '{CorrelationId}'", entry.CorrelationId ?? "<none>");
 

--- a/samples/Foundatio.AzureServiceBus.Enqueue/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Enqueue/Program.cs
@@ -57,10 +57,10 @@ rootCommand.SetAction(async parseResult =>
                               Environment.GetEnvironmentVariable("AZURE_SERVICEBUS_CONNECTION_STRING") ??
                               EmulatorConnectionString;
 
-    string queueName = parseResult.GetValue(queueOption);
-    string message = parseResult.GetValue(messageOption);
-    string correlationId = parseResult.GetValue(correlationIdOption);
-    string[] properties = parseResult.GetValue(propertiesOption);
+    string queueName = parseResult.GetValue(queueOption)!;
+    string message = parseResult.GetValue(messageOption)!;
+    string? correlationId = parseResult.GetValue(correlationIdOption);
+    string[] properties = parseResult.GetValue(propertiesOption)!;
     int count = parseResult.GetValue(countOption);
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Service Bus Emulator" : "Custom connection string")}");
@@ -72,7 +72,7 @@ rootCommand.SetAction(async parseResult =>
 
 return await rootCommand.Parse(args).InvokeAsync();
 
-static async Task EnqueueMessages(string connectionString, string queueName, string message, string correlationId, string[] properties, int count)
+static async Task EnqueueMessages(string connectionString, string queueName, string message, string? correlationId, string[] properties, int count)
 {
     using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Information));
     var logger = loggerFactory.CreateLogger("Enqueue");
@@ -105,11 +105,16 @@ static async Task EnqueueMessages(string connectionString, string queueName, str
 
         var entryOptions = new QueueEntryOptions
         {
-            CorrelationId = correlationId,
-            Properties = queueProperties.Count > 0 ? queueProperties : null
+            CorrelationId = correlationId
         };
 
-        string messageId = await queue.EnqueueAsync(sampleMessage, entryOptions);
+        if (queueProperties.Count > 0)
+        {
+            foreach (var property in queueProperties)
+                entryOptions.Properties[property.Key] = property.Value;
+        }
+
+        string? messageId = await queue.EnqueueAsync(sampleMessage, entryOptions);
 
         logger.LogInformation("Enqueued message {MessageId}: '{Message}' with CorrelationId: '{CorrelationId}' Properties: [{Properties}]",
             messageId, sampleMessage.Message, correlationId ?? "<none>",

--- a/samples/Foundatio.AzureServiceBus.Enqueue/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Enqueue/Program.cs
@@ -105,14 +105,9 @@ static async Task EnqueueMessages(string connectionString, string queueName, str
 
         var entryOptions = new QueueEntryOptions
         {
-            CorrelationId = correlationId
+            CorrelationId = correlationId,
+            Properties = queueProperties
         };
-
-        if (queueProperties.Count > 0)
-        {
-            foreach (var property in queueProperties)
-                entryOptions.Properties[property.Key] = property.Value;
-        }
 
         string? messageId = await queue.EnqueueAsync(sampleMessage, entryOptions);
 

--- a/samples/Foundatio.AzureServiceBus.Enqueue/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Enqueue/Program.cs
@@ -57,10 +57,14 @@ rootCommand.SetAction(async parseResult =>
                               Environment.GetEnvironmentVariable("AZURE_SERVICEBUS_CONNECTION_STRING") ??
                               EmulatorConnectionString;
 
-    string queueName = parseResult.GetValue(queueOption)!;
-    string message = parseResult.GetValue(messageOption)!;
+    string? queueName = parseResult.GetValue(queueOption);
+    ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
+
+    string? message = parseResult.GetValue(messageOption);
+    ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
     string? correlationId = parseResult.GetValue(correlationIdOption);
-    string[] properties = parseResult.GetValue(propertiesOption)!;
+    string[] properties = parseResult.GetValue(propertiesOption) ?? [];
     int count = parseResult.GetValue(countOption);
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Service Bus Emulator" : "Custom connection string")}");

--- a/samples/Foundatio.AzureServiceBus.Enqueue/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Enqueue/Program.cs
@@ -109,9 +109,11 @@ static async Task EnqueueMessages(string connectionString, string queueName, str
 
         var entryOptions = new QueueEntryOptions
         {
-            CorrelationId = correlationId,
-            Properties = queueProperties
+            CorrelationId = correlationId
         };
+
+        if (queueProperties.Count > 0)
+            entryOptions.Properties = queueProperties;
 
         string? messageId = await queue.EnqueueAsync(sampleMessage, entryOptions);
 

--- a/samples/Foundatio.AzureServiceBus.Enqueue/SampleMessage.cs
+++ b/samples/Foundatio.AzureServiceBus.Enqueue/SampleMessage.cs
@@ -4,7 +4,7 @@ namespace Foundatio.AzureServiceBus.Samples;
 
 public record SampleMessage
 {
-    public string Message { get; init; } = String.Empty;
+    public required string Message { get; init; }
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
-    public string Source { get; init; } = String.Empty;
+    public required string Source { get; init; }
 }

--- a/samples/Foundatio.AzureServiceBus.Publish/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Publish/Program.cs
@@ -55,10 +55,10 @@ rootCommand.SetAction(async parseResult =>
                               Environment.GetEnvironmentVariable("AZURE_SERVICEBUS_CONNECTION_STRING") ??
                               EmulatorConnectionString;
 
-    string topic = parseResult.GetValue(topicOption);
-    string eventType = parseResult.GetValue(eventTypeOption);
-    string data = parseResult.GetValue(dataOption);
-    string correlationId = parseResult.GetValue(correlationIdOption);
+    string topic = parseResult.GetValue(topicOption)!;
+    string eventType = parseResult.GetValue(eventTypeOption)!;
+    string data = parseResult.GetValue(dataOption)!;
+    string? correlationId = parseResult.GetValue(correlationIdOption);
     int count = parseResult.GetValue(countOption);
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Service Bus Emulator" : "Custom connection string")}");
@@ -70,7 +70,7 @@ rootCommand.SetAction(async parseResult =>
 
 return await rootCommand.Parse(args).InvokeAsync();
 
-static async Task PublishMessages(string connectionString, string topic, string eventType, string data, string correlationId, int count)
+static async Task PublishMessages(string connectionString, string topic, string eventType, string data, string? correlationId, int count)
 {
     using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Information));
     var logger = loggerFactory.CreateLogger("Publish");

--- a/samples/Foundatio.AzureServiceBus.Publish/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Publish/Program.cs
@@ -55,9 +55,15 @@ rootCommand.SetAction(async parseResult =>
                               Environment.GetEnvironmentVariable("AZURE_SERVICEBUS_CONNECTION_STRING") ??
                               EmulatorConnectionString;
 
-    string topic = parseResult.GetValue(topicOption)!;
-    string eventType = parseResult.GetValue(eventTypeOption)!;
-    string data = parseResult.GetValue(dataOption)!;
+    string? topic = parseResult.GetValue(topicOption);
+    ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+
+    string? eventType = parseResult.GetValue(eventTypeOption);
+    ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
+
+    string? data = parseResult.GetValue(dataOption);
+    ArgumentException.ThrowIfNullOrWhiteSpace(data);
+
     string? correlationId = parseResult.GetValue(correlationIdOption);
     int count = parseResult.GetValue(countOption);
 

--- a/samples/Foundatio.AzureServiceBus.Publish/SampleEvent.cs
+++ b/samples/Foundatio.AzureServiceBus.Publish/SampleEvent.cs
@@ -4,8 +4,8 @@ namespace Foundatio.AzureServiceBus.Samples;
 
 public record SampleEvent
 {
-    public string EventType { get; init; } = String.Empty;
-    public string Data { get; init; } = String.Empty;
+    public required string EventType { get; init; }
+    public required string Data { get; init; }
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
-    public string Source { get; init; } = String.Empty;
+    public required string Source { get; init; }
 }

--- a/samples/Foundatio.AzureServiceBus.Subscribe/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Subscribe/Program.cs
@@ -36,8 +36,8 @@ rootCommand.SetAction(async parseResult =>
                               Environment.GetEnvironmentVariable("AZURE_SERVICEBUS_CONNECTION_STRING") ??
                               EmulatorConnectionString;
 
-    string topic = parseResult.GetValue(topicOption);
-    string subscription = parseResult.GetValue(subscriptionOption);
+    string topic = parseResult.GetValue(topicOption)!;
+    string subscription = parseResult.GetValue(subscriptionOption)!;
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Service Bus Emulator" : "Custom connection string")}");
     Console.WriteLine($"Topic: {topic}");

--- a/samples/Foundatio.AzureServiceBus.Subscribe/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Subscribe/Program.cs
@@ -36,8 +36,11 @@ rootCommand.SetAction(async parseResult =>
                               Environment.GetEnvironmentVariable("AZURE_SERVICEBUS_CONNECTION_STRING") ??
                               EmulatorConnectionString;
 
-    string topic = parseResult.GetValue(topicOption)!;
-    string subscription = parseResult.GetValue(subscriptionOption)!;
+    string? topic = parseResult.GetValue(topicOption);
+    ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+
+    string? subscription = parseResult.GetValue(subscriptionOption);
+    ArgumentException.ThrowIfNullOrWhiteSpace(subscription);
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Service Bus Emulator" : "Custom connection string")}");
     Console.WriteLine($"Topic: {topic}");

--- a/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
+++ b/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Identity" Version="1.20.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
+++ b/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Identity" Version="1.20.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
+++ b/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Identity" Version="1.20.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
+++ b/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Identity" Version="1.20.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -243,13 +243,9 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
             _logger.LogTrace("Message Publish: {MessageType}", messageType);
         }
 
-        var sender = _topicSender;
-        if (sender is null)
-            throw new MessageBusException("Cannot publish: topic sender is not initialized or has been closed.");
-
         // Wrap only the transport call in resilience policy
         await _resiliencePolicy.ExecuteAsync(async _ =>
-            await sender.SendMessageAsync(serviceBusMessage, cancellationToken),
+            await _topicSender!.SendMessageAsync(serviceBusMessage, cancellationToken),
             cancellationToken).AnyContext();
     }
 

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundatio.Messaging;
 
-public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBusOptions>
+public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBusOptions>, IAsyncDisposable
 {
     private readonly AsyncLock _lock = new();
     private readonly Lazy<ServiceBusClient> _client;
@@ -342,6 +342,18 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         }
     }
 
+    public async ValueTask DisposeAsync()
+    {
+        base.Dispose();
+        await CloseTopicSenderAsync().AnyContext();
+        await CloseSubscriptionProcessorAsync().AnyContext();
+
+        if (_client.IsValueCreated)
+        {
+            await _client.Value.DisposeAsync().AnyContext();
+        }
+    }
+
     private void CloseTopicSender()
     {
         if (_topicSender is null)
@@ -353,6 +365,21 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
                 return;
 
             _topicSender.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            _topicSender = null;
+        }
+    }
+
+    private async Task CloseTopicSenderAsync()
+    {
+        if (_topicSender is null)
+            return;
+
+        using (await _lock.LockAsync().AnyContext())
+        {
+            if (_topicSender is null)
+                return;
+
+            await _topicSender.DisposeAsync().AnyContext();
             _topicSender = null;
         }
     }
@@ -369,6 +396,22 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
             _subscriptionProcessor.StopProcessingAsync().GetAwaiter().GetResult();
             _subscriptionProcessor.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            _subscriptionProcessor = null;
+        }
+    }
+
+    private async Task CloseSubscriptionProcessorAsync()
+    {
+        if (_subscriptionProcessor is null)
+            return;
+
+        using (await _lock.LockAsync().AnyContext())
+        {
+            if (_subscriptionProcessor is null)
+                return;
+
+            await _subscriptionProcessor.StopProcessingAsync().AnyContext();
+            await _subscriptionProcessor.DisposeAsync().AnyContext();
             _subscriptionProcessor = null;
         }
     }

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -359,15 +359,17 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
     private void CloseTopicSender()
     {
-        if (_topicSender is null)
+        var sender = _topicSender;
+        if (sender is null)
             return;
 
         using (_lock.Lock())
         {
-            if (_topicSender is null)
+            sender = _topicSender;
+            if (sender is null)
                 return;
 
-            _topicSender.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            sender.DisposeAsync().AsTask().GetAwaiter().GetResult();
             _topicSender = null;
         }
     }
@@ -389,16 +391,18 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
     private void CloseSubscriptionProcessor()
     {
-        if (_subscriptionProcessor is null)
+        var processor = _subscriptionProcessor;
+        if (processor is null)
             return;
 
         using (_lock.Lock())
         {
-            if (_subscriptionProcessor is null)
+            processor = _subscriptionProcessor;
+            if (processor is null)
                 return;
 
-            _subscriptionProcessor.StopProcessingAsync().GetAwaiter().GetResult();
-            _subscriptionProcessor.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            processor.StopProcessingAsync().GetAwaiter().GetResult();
+            processor.DisposeAsync().AsTask().GetAwaiter().GetResult();
             _subscriptionProcessor = null;
         }
     }

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -85,7 +85,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
                     if (!subscriptionExists)
                     {
                         if (!_options.CanCreateTopic)
-                            throw new InvalidOperationException($"Subscription {_subscriptionName} does not exist on topic {_options.Topic} and CanCreateTopic is false.");
+                            throw new MessageBusException($"Subscription {_subscriptionName} does not exist on topic {_options.Topic} and CanCreateTopic is false.");
 
                         await _adminClient.Value.CreateSubscriptionAsync(CreateSubscriptionOptions(), cancellationToken).AnyContext();
                         _logger.LogDebug("Created subscription {SubscriptionName} on topic {Topic}", _subscriptionName, _options.Topic);
@@ -195,7 +195,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
                     if (!topicExists)
                     {
                         if (!_options.CanCreateTopic)
-                            throw new InvalidOperationException($"Topic {_options.Topic} does not exist and CanCreateTopic is false.");
+                            throw new MessageBusException($"Topic {_options.Topic} does not exist and CanCreateTopic is false.");
 
                         await _adminClient.Value.CreateTopicAsync(CreateTopicOptions(), cancellationToken).AnyContext();
                         _logger.LogDebug("Created topic {Topic}", _options.Topic);
@@ -247,6 +247,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         if (sender is null)
             throw new MessageBusException("Cannot publish: topic sender is not initialized or has been closed.");
 
+        // Wrap only the transport call in resilience policy
         await _resiliencePolicy.ExecuteAsync(async _ =>
             await sender.SendMessageAsync(serviceBusMessage, cancellationToken),
             cancellationToken).AnyContext();

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -334,10 +334,9 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
     public override void Dispose()
     {
-        // TODO: Improve Async Cleanup
         base.Dispose();
-        CloseTopicSender();
-        CloseSubscriptionProcessor();
+        CloseTopicSenderAsync().GetAwaiter().GetResult();
+        CloseSubscriptionProcessorAsync().GetAwaiter().GetResult();
 
         if (_client.IsValueCreated)
         {
@@ -357,23 +356,6 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         }
     }
 
-    private void CloseTopicSender()
-    {
-        var sender = _topicSender;
-        if (sender is null)
-            return;
-
-        using (_lock.Lock())
-        {
-            sender = _topicSender;
-            if (sender is null)
-                return;
-
-            sender.DisposeAsync().AsTask().GetAwaiter().GetResult();
-            _topicSender = null;
-        }
-    }
-
     private async Task CloseTopicSenderAsync()
     {
         if (_topicSender is null)
@@ -386,24 +368,6 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
             await _topicSender.DisposeAsync().AnyContext();
             _topicSender = null;
-        }
-    }
-
-    private void CloseSubscriptionProcessor()
-    {
-        var processor = _subscriptionProcessor;
-        if (processor is null)
-            return;
-
-        using (_lock.Lock())
-        {
-            processor = _subscriptionProcessor;
-            if (processor is null)
-                return;
-
-            processor.StopProcessingAsync().GetAwaiter().GetResult();
-            processor.DisposeAsync().AsTask().GetAwaiter().GetResult();
-            _subscriptionProcessor = null;
         }
     }
 

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -11,14 +11,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundatio.Messaging;
 
-public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBusOptions>, IAsyncDisposable
+public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBusOptions>
 {
     private readonly AsyncLock _lock = new();
     private readonly Lazy<ServiceBusClient> _client;
     private readonly Lazy<ServiceBusAdministrationClient> _adminClient;
     private readonly bool _isEmulator;
-    private ServiceBusSender _topicSender;
-    private ServiceBusProcessor _subscriptionProcessor;
+    private ServiceBusSender? _topicSender;
+    private ServiceBusProcessor? _subscriptionProcessor;
     private readonly string _subscriptionName;
 
     public AzureServiceBusMessageBus(AzureServiceBusMessageBusOptions options) : base(options)
@@ -63,7 +63,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
     protected override async Task EnsureTopicSubscriptionAsync(CancellationToken cancellationToken)
     {
-        if (_subscriptionProcessor != null)
+        if (_subscriptionProcessor is not null)
             return;
 
         if (!TopicIsCreated)
@@ -71,7 +71,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
         using (await _lock.LockAsync(cancellationToken).AnyContext())
         {
-            if (_subscriptionProcessor != null)
+            if (_subscriptionProcessor is not null)
                 return;
 
             _logger.LogTrace("Ensuring subscription {SubscriptionName} exists on topic {Topic}", _subscriptionName, _options.Topic);
@@ -145,7 +145,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
             if (ServiceBusMessageHelper.IsSdkDiagnosticProperty(property.Key))
                 continue;
 
-            message.Properties[property.Key] = property.Value?.ToString();
+            message.Properties[property.Key] = property.Value?.ToString() ?? String.Empty;
         }
 
         try
@@ -171,7 +171,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         return Task.CompletedTask;
     }
 
-    private bool TopicIsCreated => _topicSender != null;
+    private bool TopicIsCreated => _topicSender is not null;
 
     protected override async Task EnsureTopicCreatedAsync(CancellationToken cancellationToken)
     {
@@ -244,7 +244,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
         // Wrap only the transport call in resilience policy
         await _resiliencePolicy.ExecuteAsync(async _ =>
-            await _topicSender.SendMessageAsync(serviceBusMessage, cancellationToken),
+            await _topicSender!.SendMessageAsync(serviceBusMessage, cancellationToken),
             cancellationToken).AnyContext();
     }
 
@@ -330,9 +330,10 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
     public override void Dispose()
     {
+        // TODO: Improve Async Cleanup
         base.Dispose();
-        CloseTopicSenderAsync().GetAwaiter().GetResult();
-        CloseSubscriptionProcessorAsync().GetAwaiter().GetResult();
+        CloseTopicSender();
+        CloseSubscriptionProcessor();
 
         if (_client.IsValueCreated)
         {
@@ -340,45 +341,33 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         }
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        base.Dispose();
-        await CloseTopicSenderAsync().AnyContext();
-        await CloseSubscriptionProcessorAsync().AnyContext();
-
-        if (_client.IsValueCreated)
-        {
-            await _client.Value.DisposeAsync().AnyContext();
-        }
-    }
-
-    private async Task CloseTopicSenderAsync()
+    private void CloseTopicSender()
     {
         if (_topicSender is null)
             return;
 
-        using (await _lock.LockAsync().AnyContext())
+        using (_lock.Lock())
         {
             if (_topicSender is null)
                 return;
 
-            await _topicSender.DisposeAsync().AnyContext();
+            _topicSender.DisposeAsync().AsTask().GetAwaiter().GetResult();
             _topicSender = null;
         }
     }
 
-    private async Task CloseSubscriptionProcessorAsync()
+    private void CloseSubscriptionProcessor()
     {
         if (_subscriptionProcessor is null)
             return;
 
-        using (await _lock.LockAsync().AnyContext())
+        using (_lock.Lock())
         {
             if (_subscriptionProcessor is null)
                 return;
 
-            await _subscriptionProcessor.StopProcessingAsync().AnyContext();
-            await _subscriptionProcessor.DisposeAsync().AnyContext();
+            _subscriptionProcessor.StopProcessingAsync().GetAwaiter().GetResult();
+            _subscriptionProcessor.DisposeAsync().AsTask().GetAwaiter().GetResult();
             _subscriptionProcessor = null;
         }
     }

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -243,9 +243,12 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
             _logger.LogTrace("Message Publish: {MessageType}", messageType);
         }
 
-        // Wrap only the transport call in resilience policy
+        var sender = _topicSender;
+        if (sender is null)
+            throw new MessageBusException("Cannot publish: topic sender is not initialized or has been closed.");
+
         await _resiliencePolicy.ExecuteAsync(async _ =>
-            await _topicSender!.SendMessageAsync(serviceBusMessage, cancellationToken),
+            await sender.SendMessageAsync(serviceBusMessage, cancellationToken),
             cancellationToken).AnyContext();
     }
 

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -145,7 +145,8 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
             if (ServiceBusMessageHelper.IsSdkDiagnosticProperty(property.Key))
                 continue;
 
-            message.Properties[property.Key] = property.Value?.ToString() ?? String.Empty;
+            if (property.Value?.ToString() is { } value)
+                message.Properties[property.Key] = value;
         }
 
         try

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBusOptions.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBusOptions.cs
@@ -10,18 +10,18 @@ public class AzureServiceBusMessageBusOptions : SharedMessageBusOptions
     /// <summary>
     /// The connection string to the Azure Service Bus namespace.
     /// </summary>
-    public string ConnectionString { get; set; }
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// The fully qualified Service Bus namespace to use for Azure Identity authentication.
     /// Example: "yournamespace.servicebus.windows.net"
     /// </summary>
-    public string FullyQualifiedNamespace { get; set; }
+    public string? FullyQualifiedNamespace { get; set; }
 
     /// <summary>
     /// The token credential to use for Azure Identity authentication.
     /// </summary>
-    public TokenCredential Credential { get; set; }
+    public TokenCredential? Credential { get; set; }
 
     /// <summary>
     /// Whether the topic can be created if it doesn't exist.
@@ -87,12 +87,12 @@ public class AzureServiceBusMessageBusOptions : SharedMessageBusOptions
     /// <summary>
     /// Returns user metadata.
     /// </summary>
-    public string TopicUserMetadata { get; set; }
+    public string? TopicUserMetadata { get; set; }
 
     /// <summary>
     /// If no subscription name is specified, then a fanout type message bus will be created.
     /// </summary>
-    public string SubscriptionName { get; set; }
+    public string? SubscriptionName { get; set; }
 
     /// <summary>
     /// The idle interval after which the subscription is automatically deleted. The minimum duration is 5 minutes.
@@ -142,17 +142,17 @@ public class AzureServiceBusMessageBusOptions : SharedMessageBusOptions
     /// <summary>
     /// Returns the path to the recipient to which the message is forwarded.
     /// </summary>
-    public string SubscriptionForwardTo { get; set; }
+    public string? SubscriptionForwardTo { get; set; }
 
     /// <summary>
     /// Returns the path to the recipient to which the dead lettered message is forwarded.
     /// </summary>
-    public string SubscriptionForwardDeadLetteredMessagesTo { get; set; }
+    public string? SubscriptionForwardDeadLetteredMessagesTo { get; set; }
 
     /// <summary>
     /// Returns user metadata.
     /// </summary>
-    public string SubscriptionUserMetadata { get; set; }
+    public string? SubscriptionUserMetadata { get; set; }
 
     /// <summary>
     /// The receive mode for the subscription processor.

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBusOptions.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBusOptions.cs
@@ -166,23 +166,22 @@ public class AzureServiceBusMessageBusOptionsBuilder : SharedMessageBusOptionsBu
 {
     public AzureServiceBusMessageBusOptionsBuilder ConnectionString(string connectionString)
     {
-        if (String.IsNullOrEmpty(connectionString))
-            throw new ArgumentNullException(nameof(connectionString));
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
         Target.ConnectionString = connectionString;
         return this;
     }
 
     public AzureServiceBusMessageBusOptionsBuilder FullyQualifiedNamespace(string fullyQualifiedNamespace)
     {
-        if (String.IsNullOrEmpty(fullyQualifiedNamespace))
-            throw new ArgumentNullException(nameof(fullyQualifiedNamespace));
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullyQualifiedNamespace);
         Target.FullyQualifiedNamespace = fullyQualifiedNamespace;
         return this;
     }
 
     public AzureServiceBusMessageBusOptionsBuilder Credential(TokenCredential credential)
     {
-        Target.Credential = credential ?? throw new ArgumentNullException(nameof(credential));
+        ArgumentNullException.ThrowIfNull(credential);
+        Target.Credential = credential;
         return this;
     }
 
@@ -264,13 +263,15 @@ public class AzureServiceBusMessageBusOptionsBuilder : SharedMessageBusOptionsBu
 
     public AzureServiceBusMessageBusOptionsBuilder TopicUserMetadata(string topicUserMetadata)
     {
-        Target.TopicUserMetadata = topicUserMetadata ?? throw new ArgumentNullException(nameof(topicUserMetadata));
+        ArgumentNullException.ThrowIfNull(topicUserMetadata);
+        Target.TopicUserMetadata = topicUserMetadata;
         return this;
     }
 
     public AzureServiceBusMessageBusOptionsBuilder SubscriptionName(string subscriptionName)
     {
-        Target.SubscriptionName = subscriptionName ?? throw new ArgumentNullException(nameof(subscriptionName));
+        ArgumentNullException.ThrowIfNull(subscriptionName);
+        Target.SubscriptionName = subscriptionName;
         return this;
     }
 
@@ -330,19 +331,22 @@ public class AzureServiceBusMessageBusOptionsBuilder : SharedMessageBusOptionsBu
 
     public AzureServiceBusMessageBusOptionsBuilder SubscriptionForwardTo(string subscriptionForwardTo)
     {
-        Target.SubscriptionForwardTo = subscriptionForwardTo ?? throw new ArgumentNullException(nameof(subscriptionForwardTo));
+        ArgumentNullException.ThrowIfNull(subscriptionForwardTo);
+        Target.SubscriptionForwardTo = subscriptionForwardTo;
         return this;
     }
 
     public AzureServiceBusMessageBusOptionsBuilder SubscriptionForwardDeadLetteredMessagesTo(string subscriptionForwardDeadLetteredMessagesTo)
     {
-        Target.SubscriptionForwardDeadLetteredMessagesTo = subscriptionForwardDeadLetteredMessagesTo ?? throw new ArgumentNullException(nameof(subscriptionForwardDeadLetteredMessagesTo));
+        ArgumentNullException.ThrowIfNull(subscriptionForwardDeadLetteredMessagesTo);
+        Target.SubscriptionForwardDeadLetteredMessagesTo = subscriptionForwardDeadLetteredMessagesTo;
         return this;
     }
 
     public AzureServiceBusMessageBusOptionsBuilder SubscriptionUserMetadata(string subscriptionUserMetadata)
     {
-        Target.SubscriptionUserMetadata = subscriptionUserMetadata ?? throw new ArgumentNullException(nameof(subscriptionUserMetadata));
+        ArgumentNullException.ThrowIfNull(subscriptionUserMetadata);
+        Target.SubscriptionUserMetadata = subscriptionUserMetadata;
         return this;
     }
 

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -177,10 +177,6 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
     {
         await EnsureQueueCreatedAsync().AnyContext();
 
-        var receiver = _queueReceiver;
-        if (receiver is null)
-            throw new QueueException("Cannot drain: queue receiver is not initialized.");
-
         int totalDrained = 0;
         int passes = 0;
         const int maxPasses = 5;
@@ -194,7 +190,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             int drained = 0;
             while (!DisposedCancellationToken.IsCancellationRequested)
             {
-                var messages = await receiver.ReceiveMessagesAsync(100, TimeSpan.FromSeconds(1), DisposedCancellationToken).AnyContext();
+                var messages = await _queueReceiver!.ReceiveMessagesAsync(100, TimeSpan.FromSeconds(1), DisposedCancellationToken).AnyContext();
                 if (messages == null || messages.Count == 0)
                     break;
 
@@ -203,7 +199,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
                     if (DisposedCancellationToken.IsCancellationRequested)
                         break;
 
-                    await receiver.CompleteMessageAsync(message, DisposedCancellationToken).AnyContext();
+                    await _queueReceiver!.CompleteMessageAsync(message, DisposedCancellationToken).AnyContext();
                     drained++;
                 }
             }
@@ -317,11 +313,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         _logger.LogTrace("Enqueuing message to queue {QueueName}", _options.Name);
 
-        var sender = _queueSender;
-        if (sender is null)
-            throw new QueueException("Cannot enqueue: queue sender is not initialized.");
-
-        await sender.SendMessageAsync(message).AnyContext();
+        await _queueSender!.SendMessageAsync(message).AnyContext();
 
         var entry = new QueueEntry<T>(message.MessageId, message.CorrelationId, data, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
 
@@ -350,15 +342,11 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         ServiceBusReceivedMessage? message = null;
 
-        var receiver = _queueReceiver;
-        if (receiver is null)
-            throw new QueueException("Cannot dequeue: queue receiver is not initialized.");
-
         // Initial receive attempt - try at least once even if cancellation is requested
         // This supports the pattern where TimeSpan.Zero is passed to mean "check once without waiting"
         try
         {
-            message = await receiver.ReceiveMessageAsync(timeout, CancellationToken.None).AnyContext();
+            message = await _queueReceiver!.ReceiveMessageAsync(timeout, CancellationToken.None).AnyContext();
         }
         catch (OperationCanceledException)
         {
@@ -384,7 +372,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
             try
             {
-                message = await receiver.ReceiveMessageAsync(_options.ReadQueueTimeout, linkedCancellationToken).AnyContext();
+                message = await _queueReceiver!.ReceiveMessageAsync(_options.ReadQueueTimeout, linkedCancellationToken).AnyContext();
             }
             catch (OperationCanceledException)
             {
@@ -442,11 +430,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         var entry = ToQueueEntry(queueEntry);
 
-        var receiver = _queueReceiver;
-        if (receiver is null)
-            throw new QueueException("Cannot renew lock: queue receiver is not initialized.");
-
-        await receiver.RenewMessageLockAsync(entry.UnderlyingMessage).AnyContext();
+        await _queueReceiver!.RenewMessageLockAsync(entry.UnderlyingMessage).AnyContext();
 
         await OnLockRenewedAsync(entry).AnyContext();
         _logger.LogTrace("Renew lock done: {QueueEntryId} MessageId={MessageId}", queueEntry.Id, entry.UnderlyingMessage.MessageId);
@@ -461,11 +445,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         var entry = ToQueueEntry(queueEntry);
 
-        var receiver = _queueReceiver;
-        if (receiver is null)
-            throw new QueueException("Cannot complete: queue receiver is not initialized.");
-
-        await receiver.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
+        await _queueReceiver!.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
 
         Interlocked.Increment(ref _completedCount);
         queueEntry.MarkCompleted();
@@ -481,10 +461,6 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             throw new QueueException("Queue entry has already been completed or abandoned.");
 
         var entry = ToQueueEntry(queueEntry);
-
-        var receiver = _queueReceiver;
-        if (receiver is null)
-            throw new QueueException("Cannot abandon: queue receiver is not initialized.");
 
         if (entry.Attempts > _options.Retries)
         {
@@ -521,18 +497,14 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
                 retryMessage.ApplicationProperties["_attempts"] = entry.Attempts;
 
                 // Complete the original message and schedule the retry
-                await receiver.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
+                await _queueReceiver!.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
 
-                var retrySender = _queueSender;
-                if (retrySender is null)
-                    throw new QueueException("Cannot schedule retry: queue sender is not initialized.");
-
-                await retrySender.SendMessageAsync(retryMessage).AnyContext();
+                await _queueSender!.SendMessageAsync(retryMessage).AnyContext();
             }
             else
             {
                 // No retry delay - just abandon for immediate retry
-                await receiver.AbandonMessageAsync(entry.UnderlyingMessage).AnyContext();
+                await _queueReceiver!.AbandonMessageAsync(entry.UnderlyingMessage).AnyContext();
             }
         }
 
@@ -689,11 +661,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
     {
         _logger.LogInformation("Exceeded retry limit ({Attempts}/{Retries}), moving message {QueueEntryId} to dead letter", entry.Attempts, _options.Retries, entry.Id);
 
-        var receiver = _queueReceiver;
-        if (receiver is null)
-            throw new QueueException("Cannot dead-letter: queue receiver is not initialized.");
-
-        await receiver.DeadLetterMessageAsync(entry.UnderlyingMessage, "MaxRetriesExceeded",
+        await _queueReceiver!.DeadLetterMessageAsync(entry.UnderlyingMessage, "MaxRetriesExceeded",
             $"Exceeded retry limit ({entry.Attempts} attempts, {_options.Retries} retries)").AnyContext();
     }
 

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -13,14 +13,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundatio.Queues;
 
-public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<T>>, IAsyncDisposable where T : class
+public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<T>> where T : class
 {
     private readonly AsyncLock _lock = new();
     private readonly Lazy<ServiceBusClient> _client;
     private readonly Lazy<ServiceBusAdministrationClient> _adminClient;
     private readonly bool _isEmulator;
-    private ServiceBusSender _queueSender;
-    private ServiceBusReceiver _queueReceiver;
+    private ServiceBusSender? _queueSender;
+    private ServiceBusReceiver? _queueReceiver;
 
     private long _enqueuedCount;
     private long _dequeuedCount;
@@ -77,10 +77,10 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
     public ServiceBusClient Client => _client.Value;
     public ServiceBusAdministrationClient AdminClient => _adminClient.Value;
-    public ServiceBusReceiver Receiver => _queueReceiver;
-    public ServiceBusSender Sender => _queueSender;
+    public ServiceBusReceiver? Receiver => _queueReceiver;
+    public ServiceBusSender? Sender => _queueSender;
 
-    private bool QueueIsCreated => _queueReceiver != null && _queueSender != null;
+    private bool QueueIsCreated => _queueReceiver is not null && _queueSender is not null;
 
     protected override async Task EnsureQueueCreatedAsync(CancellationToken cancellationToken = default)
     {
@@ -154,13 +154,13 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             await DrainQueueAsync().AnyContext();
         }
 
-        if (_queueSender != null)
+        if (_queueSender is not null)
         {
             await _queueSender.DisposeAsync().AnyContext();
             _queueSender = null;
         }
 
-        if (_queueReceiver != null)
+        if (_queueReceiver is not null)
         {
             await _queueReceiver.DisposeAsync().AnyContext();
             _queueReceiver = null;
@@ -190,7 +190,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             int drained = 0;
             while (!DisposedCancellationToken.IsCancellationRequested)
             {
-                var messages = await _queueReceiver.ReceiveMessagesAsync(100, TimeSpan.FromSeconds(1), DisposedCancellationToken).AnyContext();
+                var messages = await _queueReceiver!.ReceiveMessagesAsync(100, TimeSpan.FromSeconds(1), DisposedCancellationToken).AnyContext();
                 if (messages == null || messages.Count == 0)
                     break;
 
@@ -199,7 +199,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
                     if (DisposedCancellationToken.IsCancellationRequested)
                         break;
 
-                    await _queueReceiver.CompleteMessageAsync(message, DisposedCancellationToken).AnyContext();
+                    await _queueReceiver!.CompleteMessageAsync(message, DisposedCancellationToken).AnyContext();
                     drained++;
                 }
             }
@@ -284,7 +284,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         throw new NotImplementedException();
     }
 
-    protected override async Task<string> EnqueueImplAsync(T data, QueueEntryOptions options)
+    protected override async Task<string?> EnqueueImplAsync(T data, QueueEntryOptions options)
     {
         if (!await OnEnqueuingAsync(data, options).AnyContext())
             return null;
@@ -312,12 +312,15 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         }
 
         _logger.LogTrace("Enqueuing message to queue {QueueName}", _options.Name);
-        await _queueSender.SendMessageAsync(message).AnyContext();
+        await _queueSender!.SendMessageAsync(message).AnyContext();
 
         var entry = new QueueEntry<T>(message.MessageId, message.CorrelationId, data, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
 
         foreach (var property in message.ApplicationProperties)
-            entry.Properties.Add(property.Key, property.Value?.ToString());
+        {
+            if (property.Value?.ToString() is { } value)
+                entry.Properties.Add(property.Key, value);
+        }
 
         await OnEnqueuedAsync(entry).AnyContext();
 
@@ -326,7 +329,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
     }
 
     // TODO: See if we can simplify this.
-    protected override async Task<IQueueEntry<T>> DequeueImplAsync(CancellationToken linkedCancellationToken)
+    protected override async Task<IQueueEntry<T>?> DequeueImplAsync(CancellationToken linkedCancellationToken)
     {
         // Calculate timeout based on cancellation state - like SQS pattern
         var timeout = linkedCancellationToken.IsCancellationRequested
@@ -336,13 +339,13 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         _logger.LogTrace("Checking for message in queue {QueueName}... IsCancellationRequested={IsCancellationRequested} ReadQueueTimeout={ReadQueueTimeout}",
             _options.Name, linkedCancellationToken.IsCancellationRequested, timeout);
 
-        ServiceBusReceivedMessage message = null;
+        ServiceBusReceivedMessage? message = null;
 
         // Initial receive attempt - try at least once even if cancellation is requested
         // This supports the pattern where TimeSpan.Zero is passed to mean "check once without waiting"
         try
         {
-            message = await _queueReceiver.ReceiveMessageAsync(timeout, CancellationToken.None).AnyContext();
+            message = await _queueReceiver!.ReceiveMessageAsync(timeout, CancellationToken.None).AnyContext();
         }
         catch (OperationCanceledException)
         {
@@ -388,7 +391,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         _logger.LogTrace("Received message {MessageId} from queue {QueueName} IsCancellationRequested={IsCancellationRequested}",
             message.MessageId, _options.Name, linkedCancellationToken.IsCancellationRequested);
 
-        T data;
+        T? data;
         try
         {
             data = _serializer.Deserialize<T>(message.Body.ToArray());
@@ -396,8 +399,12 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error deserializing message {MessageId} (delivery {DeliveryCount}), abandoning for retry", message.MessageId, message.DeliveryCount);
+            data = null;
+        }
 
-            var poisonEntry = new AzureServiceBusQueueEntry<T>(message, null, this);
+        if (data is null)
+        {
+            var poisonEntry = new AzureServiceBusQueueEntry<T>(message, default!, this);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }
@@ -420,7 +427,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         _logger.LogDebug("Queue {QueueName} renew lock item: {QueueEntryId}", _options.Name, queueEntry.Id);
 
         var entry = ToQueueEntry(queueEntry);
-        await _queueReceiver.RenewMessageLockAsync(entry.UnderlyingMessage).AnyContext();
+        await _queueReceiver!.RenewMessageLockAsync(entry.UnderlyingMessage).AnyContext();
 
         await OnLockRenewedAsync(entry).AnyContext();
         _logger.LogTrace("Renew lock done: {QueueEntryId} MessageId={MessageId}", queueEntry.Id, entry.UnderlyingMessage.MessageId);
@@ -434,7 +441,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             throw new InvalidOperationException("Queue entry has already been completed or abandoned.");
 
         var entry = ToQueueEntry(queueEntry);
-        await _queueReceiver.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
+        await _queueReceiver!.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
 
         Interlocked.Increment(ref _completedCount);
         queueEntry.MarkCompleted();
@@ -486,13 +493,13 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
                 retryMessage.ApplicationProperties["_attempts"] = entry.Attempts;
 
                 // Complete the original message and schedule the retry
-                await _queueReceiver.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
-                await _queueSender.SendMessageAsync(retryMessage).AnyContext();
+                await _queueReceiver!.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
+                await _queueSender!.SendMessageAsync(retryMessage).AnyContext();
             }
             else
             {
                 // No retry delay - just abandon for immediate retry
-                await _queueReceiver.AbandonMessageAsync(entry.UnderlyingMessage).AnyContext();
+                await _queueReceiver!.AbandonMessageAsync(entry.UnderlyingMessage).AnyContext();
             }
         }
 
@@ -521,7 +528,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             {
                 _logger.LogTrace("WorkerLoop Signaled {QueueName}", _options.Name);
 
-                IQueueEntry<T> entry = null;
+                IQueueEntry<T>? entry = null;
                 try
                 {
                     entry = await DequeueImplAsync(linkedCancellationToken.Token).AnyContext();
@@ -604,6 +611,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
     public override void Dispose()
     {
+        // TODO: Improve Async Cleanup
         base.Dispose();
 
         if (_queueSender is not null)
@@ -624,33 +632,11 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         }
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        base.Dispose();
-
-        if (_queueSender is not null)
-        {
-            await _queueSender.DisposeAsync().AnyContext();
-            _queueSender = null;
-        }
-
-        if (_queueReceiver is not null)
-        {
-            await _queueReceiver.DisposeAsync().AnyContext();
-            _queueReceiver = null;
-        }
-
-        if (_client.IsValueCreated)
-        {
-            await _client.Value.DisposeAsync().AnyContext();
-        }
-    }
-
     private async Task DeadLetterMessageAsync(AzureServiceBusQueueEntry<T> entry)
     {
         _logger.LogInformation("Exceeded retry limit ({Attempts}/{Retries}), moving message {QueueEntryId} to dead letter", entry.Attempts, _options.Retries, entry.Id);
 
-        await _queueReceiver.DeadLetterMessageAsync(entry.UnderlyingMessage, "MaxRetriesExceeded",
+        await _queueReceiver!.DeadLetterMessageAsync(entry.UnderlyingMessage, "MaxRetriesExceeded",
             $"Exceeded retry limit ({entry.Attempts} attempts, {_options.Retries} retries)").AnyContext();
     }
 

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -177,6 +177,10 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
     {
         await EnsureQueueCreatedAsync().AnyContext();
 
+        var receiver = _queueReceiver;
+        if (receiver is null)
+            throw new InvalidOperationException("Cannot drain: queue receiver is not initialized.");
+
         int totalDrained = 0;
         int passes = 0;
         const int maxPasses = 5;
@@ -190,7 +194,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             int drained = 0;
             while (!DisposedCancellationToken.IsCancellationRequested)
             {
-                var messages = await _queueReceiver!.ReceiveMessagesAsync(100, TimeSpan.FromSeconds(1), DisposedCancellationToken).AnyContext();
+                var messages = await receiver.ReceiveMessagesAsync(100, TimeSpan.FromSeconds(1), DisposedCancellationToken).AnyContext();
                 if (messages == null || messages.Count == 0)
                     break;
 
@@ -199,7 +203,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
                     if (DisposedCancellationToken.IsCancellationRequested)
                         break;
 
-                    await _queueReceiver!.CompleteMessageAsync(message, DisposedCancellationToken).AnyContext();
+                    await receiver.CompleteMessageAsync(message, DisposedCancellationToken).AnyContext();
                     drained++;
                 }
             }
@@ -312,7 +316,12 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         }
 
         _logger.LogTrace("Enqueuing message to queue {QueueName}", _options.Name);
-        await _queueSender!.SendMessageAsync(message).AnyContext();
+
+        var sender = _queueSender;
+        if (sender is null)
+            throw new InvalidOperationException("Cannot enqueue: queue sender is not initialized.");
+
+        await sender.SendMessageAsync(message).AnyContext();
 
         var entry = new QueueEntry<T>(message.MessageId, message.CorrelationId, data, this, _timeProvider.GetUtcNow().UtcDateTime, 0);
 
@@ -341,11 +350,15 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         ServiceBusReceivedMessage? message = null;
 
+        var receiver = _queueReceiver;
+        if (receiver is null)
+            throw new InvalidOperationException("Cannot dequeue: queue receiver is not initialized.");
+
         // Initial receive attempt - try at least once even if cancellation is requested
         // This supports the pattern where TimeSpan.Zero is passed to mean "check once without waiting"
         try
         {
-            message = await _queueReceiver!.ReceiveMessageAsync(timeout, CancellationToken.None).AnyContext();
+            message = await receiver.ReceiveMessageAsync(timeout, CancellationToken.None).AnyContext();
         }
         catch (OperationCanceledException)
         {
@@ -371,7 +384,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
             try
             {
-                message = await _queueReceiver!.ReceiveMessageAsync(_options.ReadQueueTimeout, linkedCancellationToken).AnyContext();
+                message = await receiver.ReceiveMessageAsync(_options.ReadQueueTimeout, linkedCancellationToken).AnyContext();
             }
             catch (OperationCanceledException)
             {
@@ -427,7 +440,12 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         _logger.LogDebug("Queue {QueueName} renew lock item: {QueueEntryId}", _options.Name, queueEntry.Id);
 
         var entry = ToQueueEntry(queueEntry);
-        await _queueReceiver!.RenewMessageLockAsync(entry.UnderlyingMessage).AnyContext();
+
+        var receiver = _queueReceiver;
+        if (receiver is null)
+            throw new InvalidOperationException("Cannot renew lock: queue receiver is not initialized.");
+
+        await receiver.RenewMessageLockAsync(entry.UnderlyingMessage).AnyContext();
 
         await OnLockRenewedAsync(entry).AnyContext();
         _logger.LogTrace("Renew lock done: {QueueEntryId} MessageId={MessageId}", queueEntry.Id, entry.UnderlyingMessage.MessageId);
@@ -441,7 +459,12 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             throw new InvalidOperationException("Queue entry has already been completed or abandoned.");
 
         var entry = ToQueueEntry(queueEntry);
-        await _queueReceiver!.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
+
+        var receiver = _queueReceiver;
+        if (receiver is null)
+            throw new InvalidOperationException("Cannot complete: queue receiver is not initialized.");
+
+        await receiver.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
 
         Interlocked.Increment(ref _completedCount);
         queueEntry.MarkCompleted();
@@ -457,6 +480,10 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             throw new InvalidOperationException("Queue entry has already been completed or abandoned.");
 
         var entry = ToQueueEntry(queueEntry);
+
+        var receiver = _queueReceiver;
+        if (receiver is null)
+            throw new InvalidOperationException("Cannot abandon: queue receiver is not initialized.");
 
         if (entry.Attempts > _options.Retries)
         {
@@ -493,13 +520,18 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
                 retryMessage.ApplicationProperties["_attempts"] = entry.Attempts;
 
                 // Complete the original message and schedule the retry
-                await _queueReceiver!.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
-                await _queueSender!.SendMessageAsync(retryMessage).AnyContext();
+                await receiver.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
+
+                var retrySender = _queueSender;
+                if (retrySender is null)
+                    throw new InvalidOperationException("Cannot schedule retry: queue sender is not initialized.");
+
+                await retrySender.SendMessageAsync(retryMessage).AnyContext();
             }
             else
             {
                 // No retry delay - just abandon for immediate retry
-                await _queueReceiver!.AbandonMessageAsync(entry.UnderlyingMessage).AnyContext();
+                await receiver.AbandonMessageAsync(entry.UnderlyingMessage).AnyContext();
             }
         }
 
@@ -515,8 +547,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
     protected override void StartWorkingImpl(Func<IQueueEntry<T>, CancellationToken, Task> handler, bool autoComplete, CancellationToken cancellationToken)
     {
-        if (handler == null)
-            throw new ArgumentNullException(nameof(handler));
+        ArgumentNullException.ThrowIfNull(handler);
 
         var linkedCancellationToken = GetLinkedDisposableCancellationTokenSource(cancellationToken);
 
@@ -657,7 +688,11 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
     {
         _logger.LogInformation("Exceeded retry limit ({Attempts}/{Retries}), moving message {QueueEntryId} to dead letter", entry.Attempts, _options.Retries, entry.Id);
 
-        await _queueReceiver!.DeadLetterMessageAsync(entry.UnderlyingMessage, "MaxRetriesExceeded",
+        var receiver = _queueReceiver;
+        if (receiver is null)
+            throw new InvalidOperationException("Cannot dead-letter: queue receiver is not initialized.");
+
+        await receiver.DeadLetterMessageAsync(entry.UnderlyingMessage, "MaxRetriesExceeded",
             $"Exceeded retry limit ({entry.Attempts} attempts, {_options.Retries} retries)").AnyContext();
     }
 

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -371,7 +371,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
             try
             {
-                message = await _queueReceiver.ReceiveMessageAsync(_options.ReadQueueTimeout, linkedCancellationToken).AnyContext();
+                message = await _queueReceiver!.ReceiveMessageAsync(_options.ReadQueueTimeout, linkedCancellationToken).AnyContext();
             }
             catch (OperationCanceledException)
             {

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -103,7 +103,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
                     if (!queueExists)
                     {
                         if (!_options.CanCreateQueue)
-                            throw new InvalidOperationException($"Queue {_options.Name} does not exist and CanCreateQueue is false.");
+                            throw new QueueException($"Queue {_options.Name} does not exist and CanCreateQueue is false.");
 
                         await _adminClient.Value.CreateQueueAsync(CreateQueueOptions(), cancellationToken).AnyContext();
                         _logger.LogDebug("Created queue {QueueName}", _options.Name);
@@ -179,7 +179,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         var receiver = _queueReceiver;
         if (receiver is null)
-            throw new InvalidOperationException("Cannot drain: queue receiver is not initialized.");
+            throw new QueueException("Cannot drain: queue receiver is not initialized.");
 
         int totalDrained = 0;
         int passes = 0;
@@ -319,7 +319,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         var sender = _queueSender;
         if (sender is null)
-            throw new InvalidOperationException("Cannot enqueue: queue sender is not initialized.");
+            throw new QueueException("Cannot enqueue: queue sender is not initialized.");
 
         await sender.SendMessageAsync(message).AnyContext();
 
@@ -352,7 +352,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         var receiver = _queueReceiver;
         if (receiver is null)
-            throw new InvalidOperationException("Cannot dequeue: queue receiver is not initialized.");
+            throw new QueueException("Cannot dequeue: queue receiver is not initialized.");
 
         // Initial receive attempt - try at least once even if cancellation is requested
         // This supports the pattern where TimeSpan.Zero is passed to mean "check once without waiting"
@@ -412,20 +412,19 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         }
         catch (Exception ex)
         {
-            deserializeException = ex;
             data = null;
+            deserializeException = ex;
         }
 
         if (data is null)
         {
             _logger.LogWarning(deserializeException, "Error deserializing message {MessageId} (delivery {DeliveryCount}), abandoning for retry", message.MessageId, message.DeliveryCount);
-            var poisonEntry = new AzureServiceBusQueueEntry<T>(message, default!, this);
+            var poisonEntry = new AzureServiceBusQueueEntry<T>(message, null, this);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }
 
         var entry = new AzureServiceBusQueueEntry<T>(message, data, this);
-
         if (entry.Attempts > _options.Retries + 1)
         {
             await DeadLetterMessageAsync(entry).AnyContext();
@@ -445,7 +444,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         var receiver = _queueReceiver;
         if (receiver is null)
-            throw new InvalidOperationException("Cannot renew lock: queue receiver is not initialized.");
+            throw new QueueException("Cannot renew lock: queue receiver is not initialized.");
 
         await receiver.RenewMessageLockAsync(entry.UnderlyingMessage).AnyContext();
 
@@ -458,13 +457,13 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         _logger.LogDebug("Queue {QueueName} complete item: {QueueEntryId}", _options.Name, queueEntry.Id);
 
         if (queueEntry.IsAbandoned || queueEntry.IsCompleted)
-            throw new InvalidOperationException("Queue entry has already been completed or abandoned.");
+            throw new QueueException("Queue entry has already been completed or abandoned.");
 
         var entry = ToQueueEntry(queueEntry);
 
         var receiver = _queueReceiver;
         if (receiver is null)
-            throw new InvalidOperationException("Cannot complete: queue receiver is not initialized.");
+            throw new QueueException("Cannot complete: queue receiver is not initialized.");
 
         await receiver.CompleteMessageAsync(entry.UnderlyingMessage).AnyContext();
 
@@ -479,13 +478,13 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         _logger.LogDebug("Queue {QueueName} ({QueueId}) abandon item: {QueueEntryId}", _options.Name, QueueId, queueEntry.Id);
 
         if (queueEntry.IsAbandoned || queueEntry.IsCompleted)
-            throw new InvalidOperationException("Queue entry has already been completed or abandoned.");
+            throw new QueueException("Queue entry has already been completed or abandoned.");
 
         var entry = ToQueueEntry(queueEntry);
 
         var receiver = _queueReceiver;
         if (receiver is null)
-            throw new InvalidOperationException("Cannot abandon: queue receiver is not initialized.");
+            throw new QueueException("Cannot abandon: queue receiver is not initialized.");
 
         if (entry.Attempts > _options.Retries)
         {
@@ -526,7 +525,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
                 var retrySender = _queueSender;
                 if (retrySender is null)
-                    throw new InvalidOperationException("Cannot schedule retry: queue sender is not initialized.");
+                    throw new QueueException("Cannot schedule retry: queue sender is not initialized.");
 
                 await retrySender.SendMessageAsync(retryMessage).AnyContext();
             }
@@ -692,7 +691,7 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
         var receiver = _queueReceiver;
         if (receiver is null)
-            throw new InvalidOperationException("Cannot dead-letter: queue receiver is not initialized.");
+            throw new QueueException("Cannot dead-letter: queue receiver is not initialized.");
 
         await receiver.DeadLetterMessageAsync(entry.UnderlyingMessage, "MaxRetriesExceeded",
             $"Exceeded retry limit ({entry.Attempts} attempts, {_options.Retries} retries)").AnyContext();

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -405,18 +405,20 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
             message.MessageId, _options.Name, linkedCancellationToken.IsCancellationRequested);
 
         T? data;
+        Exception? deserializeException = null;
         try
         {
             data = _serializer.Deserialize<T>(message.Body.ToArray());
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error deserializing message {MessageId} (delivery {DeliveryCount}), abandoning for retry", message.MessageId, message.DeliveryCount);
+            deserializeException = ex;
             data = null;
         }
 
         if (data is null)
         {
+            _logger.LogWarning(deserializeException, "Error deserializing message {MessageId} (delivery {DeliveryCount}), abandoning for retry", message.MessageId, message.DeliveryCount);
             var poisonEntry = new AzureServiceBusQueueEntry<T>(message, default!, this);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundatio.Queues;
 
-public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<T>> where T : class
+public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<T>>, IAsyncDisposable where T : class
 {
     private readonly AsyncLock _lock = new();
     private readonly Lazy<ServiceBusClient> _client;
@@ -611,7 +611,6 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
     public override void Dispose()
     {
-        // TODO: Improve Async Cleanup
         base.Dispose();
 
         if (_queueSender is not null)
@@ -629,6 +628,28 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         if (_client.IsValueCreated)
         {
             _client.Value.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        base.Dispose();
+
+        if (_queueSender is not null)
+        {
+            await _queueSender.DisposeAsync().AnyContext();
+            _queueSender = null;
+        }
+
+        if (_queueReceiver is not null)
+        {
+            await _queueReceiver.DisposeAsync().AnyContext();
+            _queueReceiver = null;
+        }
+
+        if (_client.IsValueCreated)
+        {
+            await _client.Value.DisposeAsync().AnyContext();
         }
     }
 

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueEntry.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueEntry.cs
@@ -8,7 +8,7 @@ public class AzureServiceBusQueueEntry<T> : QueueEntry<T> where T : class
 {
     public ServiceBusReceivedMessage UnderlyingMessage { get; }
 
-    public AzureServiceBusQueueEntry(ServiceBusReceivedMessage message, T value, IQueue<T> queue)
+    public AzureServiceBusQueueEntry(ServiceBusReceivedMessage message, T? value, IQueue<T> queue)
         : base(message.MessageId, message.CorrelationId, value, queue, message.EnqueuedTime.UtcDateTime, GetAttemptCount(message))
     {
         if (message.ApplicationProperties is not null)

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueEntry.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueEntry.cs
@@ -14,7 +14,10 @@ public class AzureServiceBusQueueEntry<T> : QueueEntry<T> where T : class
         if (message.ApplicationProperties is not null)
         {
             foreach (var property in message.ApplicationProperties.Where(a => !ServiceBusMessageHelper.IsSdkDiagnosticProperty(a.Key) && a.Key != "CorrelationId" && a.Key != "_attempts"))
-                Properties.Add(property.Key, property.Value?.ToString());
+            {
+                if (property.Value?.ToString() is { } propValue)
+                    Properties.Add(property.Key, propValue);
+            }
         }
 
         UnderlyingMessage = message;
@@ -27,7 +30,7 @@ public class AzureServiceBusQueueEntry<T> : QueueEntry<T> where T : class
     private static int GetAttemptCount(ServiceBusReceivedMessage message)
     {
         // Check if we have a stored attempt count from a scheduled retry
-        if (message.ApplicationProperties.TryGetValue("_attempts", out object attemptsValue) && attemptsValue is int storedAttempts)
+        if (message.ApplicationProperties.TryGetValue("_attempts", out object? attemptsValue) && attemptsValue is int storedAttempts)
             return storedAttempts + 1; // Add 1 because this is a new delivery of that retry
 
         // Fall back to delivery count for normal abandon/retry

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueEntryOptions.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueEntryOptions.cs
@@ -4,5 +4,5 @@ namespace Foundatio.AzureServiceBus.Queues;
 
 public record AzureServiceBusQueueEntryOptions : QueueEntryOptions
 {
-    public string SessionId { get; set; }
+    public string? SessionId { get; set; }
 }

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueOptions.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Azure.Core;
 using Azure.Messaging.ServiceBus.Administration;
 
@@ -9,18 +9,18 @@ public class AzureServiceBusQueueOptions<T> : SharedQueueOptions<T> where T : cl
     /// <summary>
     /// The connection string to the Azure Service Bus namespace.
     /// </summary>
-    public string ConnectionString { get; set; }
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// The fully qualified Service Bus namespace to use for Azure Identity authentication.
     /// Example: "yournamespace.servicebus.windows.net"
     /// </summary>
-    public string FullyQualifiedNamespace { get; set; }
+    public string? FullyQualifiedNamespace { get; set; }
 
     /// <summary>
     /// The token credential to use for Azure Identity authentication.
     /// </summary>
-    public TokenCredential Credential { get; set; }
+    public TokenCredential? Credential { get; set; }
 
     /// <summary>
     /// Whether the queue can be created if it doesn't exist.
@@ -85,12 +85,12 @@ public class AzureServiceBusQueueOptions<T> : SharedQueueOptions<T> where T : cl
     /// <summary>
     /// Returns the path to the recipient to which the message is forwarded.
     /// </summary>
-    public string ForwardTo { get; set; }
+    public string? ForwardTo { get; set; }
 
     /// <summary>
     /// Returns the path to the recipient to which the dead lettered message is forwarded.
     /// </summary>
-    public string ForwardDeadLetteredMessagesTo { get; set; }
+    public string? ForwardDeadLetteredMessagesTo { get; set; }
 
     /// <summary>
     /// Returns true if the queue is to be partitioned across multiple message brokers.
@@ -100,7 +100,7 @@ public class AzureServiceBusQueueOptions<T> : SharedQueueOptions<T> where T : cl
     /// <summary>
     /// Returns user metadata.
     /// </summary>
-    public string UserMetadata { get; set; }
+    public string? UserMetadata { get; set; }
 
     /// <summary>
     /// The function to calculate retry delay based on the attempt number.

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueOptions.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueOptions.cs
@@ -119,14 +119,15 @@ public class AzureServiceBusQueueOptionsBuilder<T> : SharedQueueOptionsBuilder<T
 
     public AzureServiceBusQueueOptionsBuilder<T> FullyQualifiedNamespace(string fullyQualifiedNamespace)
     {
-        ArgumentException.ThrowIfNullOrEmpty(fullyQualifiedNamespace);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullyQualifiedNamespace);
         Target.FullyQualifiedNamespace = fullyQualifiedNamespace;
         return this;
     }
 
     public AzureServiceBusQueueOptionsBuilder<T> Credential(TokenCredential credential)
     {
-        Target.Credential = credential ?? throw new ArgumentNullException(nameof(credential));
+        ArgumentNullException.ThrowIfNull(credential);
+        Target.Credential = credential;
         return this;
     }
 
@@ -158,7 +159,8 @@ public class AzureServiceBusQueueOptionsBuilder<T> : SharedQueueOptionsBuilder<T
 
     public AzureServiceBusQueueOptionsBuilder<T> RetryDelay(Func<int, TimeSpan> retryDelay)
     {
-        Target.RetryDelay = retryDelay ?? throw new ArgumentNullException(nameof(retryDelay));
+        ArgumentNullException.ThrowIfNull(retryDelay);
+        Target.RetryDelay = retryDelay;
         return this;
     }
 
@@ -218,13 +220,15 @@ public class AzureServiceBusQueueOptionsBuilder<T> : SharedQueueOptionsBuilder<T
 
     public AzureServiceBusQueueOptionsBuilder<T> ForwardTo(string forwardTo)
     {
-        Target.ForwardTo = forwardTo ?? throw new ArgumentNullException(nameof(forwardTo));
+        ArgumentNullException.ThrowIfNull(forwardTo);
+        Target.ForwardTo = forwardTo;
         return this;
     }
 
     public AzureServiceBusQueueOptionsBuilder<T> ForwardDeadLetteredMessagesTo(string forwardDeadLetteredMessagesTo)
     {
-        Target.ForwardDeadLetteredMessagesTo = forwardDeadLetteredMessagesTo ?? throw new ArgumentNullException(nameof(forwardDeadLetteredMessagesTo));
+        ArgumentNullException.ThrowIfNull(forwardDeadLetteredMessagesTo);
+        Target.ForwardDeadLetteredMessagesTo = forwardDeadLetteredMessagesTo;
         return this;
     }
 
@@ -236,7 +240,8 @@ public class AzureServiceBusQueueOptionsBuilder<T> : SharedQueueOptionsBuilder<T
 
     public AzureServiceBusQueueOptionsBuilder<T> UserMetadata(string userMetadata)
     {
-        Target.UserMetadata = userMetadata ?? throw new ArgumentNullException(nameof(userMetadata));
+        ArgumentNullException.ThrowIfNull(userMetadata);
+        Target.UserMetadata = userMetadata;
         return this;
     }
 }

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueOptions.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueueOptions.cs
@@ -112,7 +112,7 @@ public class AzureServiceBusQueueOptionsBuilder<T> : SharedQueueOptionsBuilder<T
 {
     public AzureServiceBusQueueOptionsBuilder<T> ConnectionString(string connectionString)
     {
-        ArgumentException.ThrowIfNullOrEmpty(connectionString);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
         Target.ConnectionString = connectionString;
         return this;
     }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.AzureServiceBus.Tests/Messaging/AzureServiceBusMessageBusTests.cs
+++ b/tests/Foundatio.AzureServiceBus.Tests/Messaging/AzureServiceBusMessageBusTests.cs
@@ -19,16 +19,16 @@ public class AzureServiceBusMessageBusTests : MessageBusTestBase
 
     private static bool IsEmulator()
     {
-        string connectionString = Configuration.GetConnectionString("AzureServiceBusConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureServiceBusConnectionString");
         return !String.IsNullOrEmpty(connectionString) &&
             connectionString.Contains("UseDevelopmentEmulator=true", StringComparison.OrdinalIgnoreCase);
     }
 
     public AzureServiceBusMessageBusTests(ITestOutputHelper output) : base(output) { }
 
-    protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions> config = null)
+    protected override IMessageBus? GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions>? config = null)
     {
-        string connectionString = Configuration.GetConnectionString("AzureServiceBusConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureServiceBusConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return null;
 

--- a/tests/Foundatio.AzureServiceBus.Tests/Queues/AzureServiceBusQueueTests.cs
+++ b/tests/Foundatio.AzureServiceBus.Tests/Queues/AzureServiceBusQueueTests.cs
@@ -23,7 +23,7 @@ public class AzureServiceBusQueueTests : QueueTestBase
 
     private static bool IsEmulator()
     {
-        string connectionString = Configuration.GetConnectionString("AzureServiceBusConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureServiceBusConnectionString");
         return !String.IsNullOrEmpty(connectionString) &&
             connectionString.Contains("UseDevelopmentEmulator=true", StringComparison.OrdinalIgnoreCase);
     }
@@ -45,9 +45,9 @@ public class AzureServiceBusQueueTests : QueueTestBase
             _assertStats = false;
     }
 
-    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[] retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider timeProvider = null, ISerializer serializer = null)
+    protected override IQueue<SimpleWorkItem>? GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
-        string connectionString = Configuration.GetConnectionString("AzureServiceBusConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureServiceBusConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return null;
 


### PR DESCRIPTION
## Summary
- Replaced ineffective \<WarningsAsErrors>true</WarningsAsErrors>\ with correct \<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\
- Fixed nullable dereference warnings in sample programs

## Changes
- **build/common.props**: \WarningsAsErrors\ → \TreatWarningsAsErrors\
- **Samples**: Null-conditional access for queue entry Value properties

## Test plan
- [x] \dotnet build Foundatio.All.slnx\ — 0 warnings, 0 errors