### PR TITLE
fix: adapt Azure Service Bus MessageBus to two-phase dispose lifecycle

### DIFF
--- a/samples/Foundatio.AzureServiceBus.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Dequeue/Program.cs
@@ -67,7 +67,9 @@ static async Task DequeueMessages(string connectionString, string queueName, int
         try
         {
             cts.Cancel();
-        } catch {
+        }
+        catch
+        {
         }
 
         logger.LogInformation("Cancellation requested...");

--- a/samples/Foundatio.AzureServiceBus.Subscribe/Program.cs
+++ b/samples/Foundatio.AzureServiceBus.Subscribe/Program.cs
@@ -67,7 +67,9 @@ static async Task SubscribeToMessages(string connectionString, string topic, str
         try
         {
             cts.Cancel();
-        } catch {
+        }
+        catch
+        {
         }
 
         logger.LogInformation("Cancellation requested...");

--- a/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
+++ b/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Identity" Version="1.20.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundatio.Messaging;
 
-public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBusOptions>, IAsyncDisposable
+public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBusOptions>
 {
     private readonly AsyncLock _lock = new();
     private readonly Lazy<ServiceBusClient> _client;
@@ -141,7 +141,6 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
         foreach (var property in brokeredMessage.ApplicationProperties)
         {
-            // Filter out Azure Service Bus SDK diagnostic properties that are automatically added
             if (ServiceBusMessageHelper.IsSdkDiagnosticProperty(property.Key))
                 continue;
 
@@ -153,15 +152,15 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         {
             await SendMessageToSubscribersAsync(message).AnyContext();
         }
+        catch (OperationCanceledException)
+        {
+            // Bus is disposing — abandon message so it can be redelivered
+        }
         catch (MessageBusException)
         {
-            // SendMessageToSubscribersAsync already logged the error
-            // Azure Service Bus SDK will handle retry/dead-letter based on MaxDeliveryCount
         }
         catch (Exception ex)
         {
-            // Catch any other unexpected exceptions for defensive purposes
-            // Azure Service Bus SDK will handle retry/dead-letter based on MaxDeliveryCount
             _logger.LogError(ex, "OnMessageAsync({MessageId}) Error in subscriber: {Message}", brokeredMessage.MessageId, ex.Message);
         }
     }
@@ -329,45 +328,11 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         return options;
     }
 
-    public override void Dispose()
-    {
-        base.Dispose();
-        Task.Run(() => CleanupAsync()).GetAwaiter().GetResult();
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        base.Dispose();
-        await CleanupAsync().AnyContext();
-    }
-
-    private async Task CleanupAsync()
-    {
-        await CloseTopicSenderAsync().AnyContext();
-        await CloseSubscriptionProcessorAsync().AnyContext();
-
-        if (_client.IsValueCreated)
-        {
-            await _client.Value.DisposeAsync().AnyContext();
-        }
-    }
-
-    private async Task CloseTopicSenderAsync()
-    {
-        if (_topicSender is null)
-            return;
-
-        using (await _lock.LockAsync().AnyContext())
-        {
-            if (_topicSender is null)
-                return;
-
-            await _topicSender.DisposeAsync().AnyContext();
-            _topicSender = null;
-        }
-    }
-
-    private async Task CloseSubscriptionProcessorAsync()
+    /// <summary>
+    /// Gracefully stops the subscription processor so in-flight handlers can complete
+    /// while subscribers are still registered and the cancellation token is still active.
+    /// </summary>
+    protected override async Task ShutdownAsync()
     {
         if (_subscriptionProcessor is null)
             return;
@@ -378,8 +343,36 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
                 return;
 
             await _subscriptionProcessor.StopProcessingAsync().AnyContext();
-            await _subscriptionProcessor.DisposeAsync().AnyContext();
-            _subscriptionProcessor = null;
         }
+    }
+
+    protected override async Task CleanupAsync()
+    {
+        if (_subscriptionProcessor is not null)
+        {
+            using (await _lock.LockAsync().AnyContext())
+            {
+                if (_subscriptionProcessor is not null)
+                {
+                    await _subscriptionProcessor.DisposeAsync().AnyContext();
+                    _subscriptionProcessor = null;
+                }
+            }
+        }
+
+        if (_topicSender is not null)
+        {
+            using (await _lock.LockAsync().AnyContext())
+            {
+                if (_topicSender is not null)
+                {
+                    await _topicSender.DisposeAsync().AnyContext();
+                    _topicSender = null;
+                }
+            }
+        }
+
+        if (_client.IsValueCreated)
+            await _client.Value.DisposeAsync().AnyContext();
     }
 }

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -355,21 +355,27 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
     protected override async Task CleanupAsync()
     {
-        using (await _lock.LockAsync().AnyContext())
+        if (_subscriptionProcessor is not null)
         {
-            if (_subscriptionProcessor is not null)
+            using (await _lock.LockAsync().AnyContext())
             {
-                await _subscriptionProcessor.DisposeAsync().AnyContext();
-                _subscriptionProcessor = null;
+                if (_subscriptionProcessor is not null)
+                {
+                    await _subscriptionProcessor.DisposeAsync().AnyContext();
+                    _subscriptionProcessor = null;
+                }
             }
         }
 
-        using (await _lock.LockAsync().AnyContext())
+        if (_topicSender is not null)
         {
-            if (_topicSender is not null)
+            using (await _lock.LockAsync().AnyContext())
             {
-                await _topicSender.DisposeAsync().AnyContext();
-                _topicSender = null;
+                if (_topicSender is not null)
+                {
+                    await _topicSender.DisposeAsync().AnyContext();
+                    _topicSender = null;
+                }
             }
         }
 

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -141,6 +141,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
         foreach (var property in brokeredMessage.ApplicationProperties)
         {
+            // Filter out Azure Service Bus SDK diagnostic properties that are automatically added
             if (ServiceBusMessageHelper.IsSdkDiagnosticProperty(property.Key))
                 continue;
 
@@ -160,9 +161,13 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         }
         catch (MessageBusException)
         {
+            // SendMessageToSubscribersAsync already logged the error
+            // Azure Service Bus SDK will handle retry/dead-letter based on MaxDeliveryCount
         }
         catch (Exception ex)
         {
+            // Catch any other unexpected exceptions for defensive purposes
+            // Azure Service Bus SDK will handle retry/dead-letter based on MaxDeliveryCount
             _logger.LogError(ex, "OnMessageAsync({MessageId}) Error in subscriber: {Message}", brokeredMessage.MessageId, ex.Message);
         }
     }
@@ -334,8 +339,11 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
     /// Gracefully stops the subscription processor so in-flight handlers can complete
     /// while subscribers are still registered and the cancellation token is still active.
     /// </summary>
-    protected override async Task ShutdownAsync()
+    protected override async Task RemoveTopicSubscriptionAsync()
     {
+        if (_subscriptionProcessor is null)
+            return;
+
         using (await _lock.LockAsync().AnyContext())
         {
             if (_subscriptionProcessor is null)

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -152,9 +152,11 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         {
             await SendMessageToSubscribersAsync(message).AnyContext();
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (IsDisposed)
         {
-            // Bus is disposing — abandon message so it can be redelivered
+            // Rethrow so the Azure SDK does not auto-complete (which would lose the message).
+            // The message will be abandoned and redelivered after lock expiry.
+            throw;
         }
         catch (MessageBusException)
         {
@@ -334,9 +336,6 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
     /// </summary>
     protected override async Task ShutdownAsync()
     {
-        if (_subscriptionProcessor is null)
-            return;
-
         using (await _lock.LockAsync().AnyContext())
         {
             if (_subscriptionProcessor is null)
@@ -348,27 +347,21 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
 
     protected override async Task CleanupAsync()
     {
-        if (_subscriptionProcessor is not null)
+        using (await _lock.LockAsync().AnyContext())
         {
-            using (await _lock.LockAsync().AnyContext())
+            if (_subscriptionProcessor is not null)
             {
-                if (_subscriptionProcessor is not null)
-                {
-                    await _subscriptionProcessor.DisposeAsync().AnyContext();
-                    _subscriptionProcessor = null;
-                }
+                await _subscriptionProcessor.DisposeAsync().AnyContext();
+                _subscriptionProcessor = null;
             }
         }
 
-        if (_topicSender is not null)
+        using (await _lock.LockAsync().AnyContext())
         {
-            using (await _lock.LockAsync().AnyContext())
+            if (_topicSender is not null)
             {
-                if (_topicSender is not null)
-                {
-                    await _topicSender.DisposeAsync().AnyContext();
-                    _topicSender = null;
-                }
+                await _topicSender.DisposeAsync().AnyContext();
+                _topicSender = null;
             }
         }
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.AzureServiceBus.Tests/Messaging/AzureServiceBusMessageBusTests.cs
+++ b/tests/Foundatio.AzureServiceBus.Tests/Messaging/AzureServiceBusMessageBusTests.cs
@@ -110,24 +110,6 @@ public class AzureServiceBusMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
-    public override Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        return base.PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
-    {
-        return base.PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
-    }
-
-    [Fact]
     public override Task CanSubscribeConcurrentlyAsync()
     {
         return base.CanSubscribeConcurrentlyAsync();
@@ -237,6 +219,12 @@ public class AzureServiceBusMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
+    public override Task CanHandlePoisonedMessageAsync()
+    {
+        return base.CanHandlePoisonedMessageAsync();
+    }
+
+    [Fact]
     public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
         return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
@@ -261,6 +249,24 @@ public class AzureServiceBusMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
+    public override Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
+    {
+        return base.PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
+    {
+        return base.PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
+    {
+        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+    }
+
+    [Fact]
     public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
         return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
@@ -273,26 +279,20 @@ public class AzureServiceBusMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
-    public override Task CanHandlePoisonedMessageAsync()
+    public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
-        return base.CanHandlePoisonedMessageAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
-    {
-        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
-    {
-        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+        return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
     }
 
     [Fact]
     public override Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
     {
         return base.SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
+    {
+        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
     }
 }

--- a/tests/Foundatio.AzureServiceBus.Tests/Messaging/AzureServiceBusMessageBusTests.cs
+++ b/tests/Foundatio.AzureServiceBus.Tests/Messaging/AzureServiceBusMessageBusTests.cs
@@ -237,6 +237,42 @@ public class AzureServiceBusMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
+    public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
+    {
+        return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    {
+        return base.DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
+    {
+        return base.DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+    }
+
+    [Fact]
     public override Task CanHandlePoisonedMessageAsync()
     {
         return base.CanHandlePoisonedMessageAsync();

--- a/tests/Foundatio.AzureServiceBus.Tests/Messaging/AzureServiceBusMessageBusTests.cs
+++ b/tests/Foundatio.AzureServiceBus.Tests/Messaging/AzureServiceBusMessageBusTests.cs
@@ -231,9 +231,9 @@ public class AzureServiceBusMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
-    public override void CanDisposeWithNoSubscribersOrPublishers()
+    public override Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        base.CanDisposeWithNoSubscribersOrPublishers();
+        return base.CanDisposeWithNoSubscribersOrPublishersAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add \ShutdownAsync\ override calling \StopProcessingAsync\ for graceful drain
- Add \CleanupAsync\ override for processor/sender/client disposal
- Handle \OperationCanceledException\ in \OnMessageAsync\ to abandon messages for redelivery
- Remove ad-hoc Dispose/DisposeAsync and private cleanup methods

## Dependencies
- Depends on FoundatioFx/Foundatio#492 (core two-phase dispose)

## Test plan
- [x] Builds with local Foundatio source (\ReferenceFoundatioSource=true\)
- [ ] CI runs integration tests with Azure Service Bus