### PR TITLE
fix: correct disposal ordering to prevent ObjectDisposedException during shutdown

### DIFF
--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -622,13 +622,11 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
     public override void Dispose()
     {
-        if (IsDisposed)
+        if (!SignalDispose())
         {
             _logger.LogTrace("Queue {QueueName} ({QueueId}) dispose was already called", _options.Name, QueueId);
             return;
         }
-
-        SignalDispose();
 
         if (_queueSender is not null)
         {
@@ -652,13 +650,11 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
     public async ValueTask DisposeAsync()
     {
-        if (IsDisposed)
+        if (!SignalDispose())
         {
             _logger.LogTrace("Queue {QueueName} ({QueueId}) async dispose was already called", _options.Name, QueueId);
             return;
         }
-
-        SignalDispose();
 
         if (_queueSender is not null)
         {

--- a/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
+++ b/src/Foundatio.AzureServiceBus/Queues/AzureServiceBusQueue.cs
@@ -622,7 +622,13 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
 
     public override void Dispose()
     {
-        base.Dispose();
+        if (IsDisposed)
+        {
+            _logger.LogTrace("Queue {QueueName} ({QueueId}) dispose was already called", _options.Name, QueueId);
+            return;
+        }
+
+        SignalDispose();
 
         if (_queueSender is not null)
         {
@@ -640,11 +646,19 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         {
             _client.Value.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
+
+        base.Dispose();
     }
 
     public async ValueTask DisposeAsync()
     {
-        base.Dispose();
+        if (IsDisposed)
+        {
+            _logger.LogTrace("Queue {QueueName} ({QueueId}) async dispose was already called", _options.Name, QueueId);
+            return;
+        }
+
+        SignalDispose();
 
         if (_queueSender is not null)
         {
@@ -662,6 +676,8 @@ public class AzureServiceBusQueue<T> : QueueBase<T, AzureServiceBusQueueOptions<
         {
             await _client.Value.DisposeAsync().AnyContext();
         }
+
+        base.Dispose();
     }
 
     private async Task DeadLetterMessageAsync(AzureServiceBusQueueEntry<T> entry)

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,7 +7,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="All" />


### PR DESCRIPTION
## Summary

- Reorder AzureServiceBusQueue.Dispose() and DisposeAsync() to call SignalDispose() first (cancels the CTS token so background tasks observe shutdown), dispose resources, then call base.Dispose() last (which disposes the timer and CTS)
- Add idempotency guard with diagnostic trace logging on re-entry for both sync and async paths

This prevents a potential ObjectDisposedException if the CancellationTokenSource is disposed while background tasks are still checking the token -- the same class of bug fixed in FoundatioFx/Foundatio.Redis#165.

## Related

- FoundatioFx/Foundatio.Redis#165
- FoundatioFx/Foundatio#519

## Test plan

- [x] Builds cleanly with dotnet build -p:ReferenceFoundatioSource=true
- [ ] Existing queue tests continue to pass