### PR TITLE
perf: zero-copy receive via Body.ToMemory(); fix exception-swallowing message loss

### DIFF
--- a/samples/Foundatio.AzureServiceBus.Dequeue/Foundatio.AzureServiceBus.Dequeue.csproj
+++ b/samples/Foundatio.AzureServiceBus.Dequeue/Foundatio.AzureServiceBus.Dequeue.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Foundatio.AzureServiceBus\Foundatio.AzureServiceBus.csproj" />
     <ProjectReference Include="..\Foundatio.AzureServiceBus.Enqueue\Foundatio.AzureServiceBus.Enqueue.csproj" />
-    <PackageReference Include="System.CommandLine" Version="2.0.8" />
+    <PackageReference Include="System.CommandLine" Version="2.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
+++ b/src/Foundatio.AzureServiceBus/Foundatio.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.2-preview.0.4" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.2-preview.0.13" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -154,21 +154,20 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         }
         catch (OperationCanceledException) when (IsDisposed)
         {
-            // Rethrow so the Azure SDK abandons rather than auto-completes the message.
-            // The message will be redelivered after the lock expires.
+            // Rethrow so the Azure SDK does not auto-complete (which would lose the message).
+            // The message will be abandoned and redelivered after lock expiry.
             throw;
         }
         catch (MessageBusException)
         {
-            // SendMessageToSubscribersAsync already logged the error. Rethrow so the SDK
-            // abandons the message and the delivery count is incremented — after MaxDeliveryCount
-            // the message moves to the dead-letter queue instead of being silently lost.
-            throw;
+            // SendMessageToSubscribersAsync already logged the error
+            // Azure Service Bus SDK will handle retry/dead-letter based on MaxDeliveryCount
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "OnMessageAsync({MessageId}) Unexpected error: {Message}", brokeredMessage.MessageId, ex.Message);
-            throw;
+            // Catch any other unexpected exceptions for defensive purposes
+            // Azure Service Bus SDK will handle retry/dead-letter based on MaxDeliveryCount
+            _logger.LogError(ex, "OnMessageAsync({MessageId}) Error in subscriber: {Message}", brokeredMessage.MessageId, ex.Message);
         }
     }
 

--- a/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
+++ b/src/Foundatio.AzureServiceBus/Messaging/AzureServiceBusMessageBus.cs
@@ -130,8 +130,7 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
             .Property("MessageId", brokeredMessage.MessageId));
 
         _logger.LogTrace("OnMessageAsync({MessageId})", brokeredMessage.MessageId);
-
-        var message = new Message(brokeredMessage.Body.ToArray(), DeserializeMessageBody)
+        var message = new Message(brokeredMessage.Body.ToMemory(), DeserializeMessageBody)
         {
             Type = brokeredMessage.ContentType,
             ClrType = GetMappedMessageType(brokeredMessage.ContentType),
@@ -155,20 +154,21 @@ public class AzureServiceBusMessageBus : MessageBusBase<AzureServiceBusMessageBu
         }
         catch (OperationCanceledException) when (IsDisposed)
         {
-            // Rethrow so the Azure SDK does not auto-complete (which would lose the message).
-            // The message will be abandoned and redelivered after lock expiry.
+            // Rethrow so the Azure SDK abandons rather than auto-completes the message.
+            // The message will be redelivered after the lock expires.
             throw;
         }
         catch (MessageBusException)
         {
-            // SendMessageToSubscribersAsync already logged the error
-            // Azure Service Bus SDK will handle retry/dead-letter based on MaxDeliveryCount
+            // SendMessageToSubscribersAsync already logged the error. Rethrow so the SDK
+            // abandons the message and the delivery count is incremented — after MaxDeliveryCount
+            // the message moves to the dead-letter queue instead of being silently lost.
+            throw;
         }
         catch (Exception ex)
         {
-            // Catch any other unexpected exceptions for defensive purposes
-            // Azure Service Bus SDK will handle retry/dead-letter based on MaxDeliveryCount
-            _logger.LogError(ex, "OnMessageAsync({MessageId}) Error in subscriber: {Message}", brokeredMessage.MessageId, ex.Message);
+            _logger.LogError(ex, "OnMessageAsync({MessageId}) Unexpected error: {Message}", brokeredMessage.MessageId, ex.Message);
+            throw;
         }
     }
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.2-preview.0.4" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.2-preview.0.13" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,7 +7,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="All" />

--- a/tests/Foundatio.AzureServiceBus.Tests/Foundatio.AzureServiceBus.Tests.csproj
+++ b/tests/Foundatio.AzureServiceBus.Tests/Foundatio.AzureServiceBus.Tests.csproj
@@ -7,4 +7,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+  </ItemGroup>
 </Project>

--- a/tests/Foundatio.AzureServiceBus.Tests/Foundatio.AzureServiceBus.Tests.csproj
+++ b/tests/Foundatio.AzureServiceBus.Tests/Foundatio.AzureServiceBus.Tests.csproj
@@ -7,7 +7,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Two independent fixes to `AzureServiceBusMessageBus.OnMessageAsync`:

1. **Zero-copy receive** — use `Body.ToMemory()` instead of `Body.ToArray()`
2. **Critical bug fix** — exception handlers were swallowing exceptions, causing `AutoCompleteMessages = true` to permanently ack messages that failed processing

Companion to [FoundatioFx/Foundatio#530](https://github.com/FoundatioFx/Foundatio/pull/530) which changes `IMessage.Data` from `byte[]` to `ReadOnlyMemory<byte>`.

---

## Change 1: Zero-copy receive (`Body.ToMemory()`)

```csharp
// Before
var message = new Message(brokeredMessage.Body.ToArray(), DeserializeMessageBody)

// After
var message = new Message(brokeredMessage.Body.ToMemory(), DeserializeMessageBody)
```

`BinaryData.ToMemory()` returns a `ReadOnlyMemory<byte>` backed by the same managed array as the `BinaryData` — no copy. Azure Service Bus does **not** pool or reclaim the body buffer after the handler returns (unlike RabbitMQ), so passing the memory directly is safe for the entire message lifetime.

`MemoryMarshal.TryGetArray()` in the serializer extension always succeeds for array-backed `ReadOnlyMemory<byte>`, so deserialization also remains zero-copy on this path.

---

## Change 2: Fix critical message-loss bug

**Before** — exceptions were caught and swallowed:

```csharp
catch (MessageBusException)
{
    // logged, but exception is swallowed
}
catch (Exception ex)
{
    _logger.LogError(ex, ...);
    // exception is swallowed
}
```

**After** — exceptions are rethrown:

```csharp
catch (MessageBusException)
{
    // logged. Rethrow so SDK abandons → increments delivery count → DLQ after MaxDeliveryCount
    throw;
}
catch (Exception ex)
{
    _logger.LogError(ex, "...");
    throw;
}
```

### Why this matters

With `AutoCompleteMessages = true` (the SDK default):

| Handler returns normally | → SDK **completes** (acks) the message — message is gone forever |
|---|---|
| **Handler throws** | → SDK **abandons** the message → delivery count incremented → DLQ after `MaxDeliveryCount` |

The previous code swallowed all exceptions, so the handler always "returned normally" from the SDK's perspective. Any message that triggered a `MessageBusException` (bad payload, type not found, etc.) or an unexpected error was **silently and permanently lost** — never retried, never dead-lettered.

With the fix, failures trigger abandon → retry → DLQ, which is the expected behavior for any reliable message bus.
